### PR TITLE
style(navigation): fix navigation z-index #55

### DIFF
--- a/packages/navigation/src/navigation.less
+++ b/packages/navigation/src/navigation.less
@@ -163,7 +163,6 @@
       flex-direction: column;
 
       .container-header {
-        z-index: 100;
         display: flex;
         width: 100%;
         height: 60px;

--- a/packages/navigation/src/navigation.tsx
+++ b/packages/navigation/src/navigation.tsx
@@ -39,6 +39,10 @@ const NavigationProps = {
     type: [Number, String],
     default: 260,
   },
+  showSideNavTitle: {
+    type: Boolean,
+    default: true,
+  },
   sideTitle: {
     type: String,
     default: '',
@@ -167,7 +171,7 @@ export default defineComponent({
                         borderRight: this.navigationType !== 'top-bottom' ? 'none' : '1px solid #DCDEE5',
                       }}>
                       {
-                        this.navigationType !== 'top-bottom' && <NavigationTitle
+                        this.navigationType !== 'top-bottom' && this.showSideNavTitle && <NavigationTitle
                         style={{ flexBasis: `${this.headHeight}px` }}
                         sideTitle={this.sideTitle}>
                           {


### PR DESCRIPTION
去掉content-header的z-index配置，
添加showSideNavTitle配置，默认为true，可省略左侧导航title