### PR TITLE
fix(popover2): ts类型不统一问题处理 #498

### DIFF
--- a/packages/popover2/src/props.ts
+++ b/packages/popover2/src/props.ts
@@ -65,7 +65,7 @@ export const PopoverProps = {
   /**
    * 弹出内容绑定元素
    */
-  boundary: PropTypes.string.def(undefined),
+  boundary: PropTypes.oneOfType([PropTypes.string.def('parent'), PropTypes.instanceOf(HTMLElement)]),
 
   zIndex: PropTypes.number.def(undefined),
 


### PR DESCRIPTION
affects: @bkui-vue/popoverv2

ISSUES CLOSED: #498

<!--
请保证PR标题明确清晰, 易于理解
Keep PR title verbose enough

相关issue可以是 #编号 或者贴 issue链接
`Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


## 变更点(Changes)

- xxxx

## 相关issues (Which issues this PR fixes)

- Fixes #

## 备注(Special notes)
