### PR TITLE
fix: select noDataText, noMatchText, loadingText 三个属性设置之后导致销毁 dom 报错的问题 && 文档网站默认语言切换为英文 && bump to 0.0.1-beta.403

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bkui-vue",
   "private": true,
-  "version": "0.0.1-beta.402",
+  "version": "0.0.1-beta.403",
   "workspaces": {
     "packages": [
       "packages/!(**.bak)*",

--- a/packages/select/src/select.tsx
+++ b/packages/select/src/select.tsx
@@ -123,9 +123,6 @@ export default defineComponent({
       multiple,
       remoteMethod,
       loading,
-      loadingText,
-      noDataText,
-      noMatchText,
       popoverMinWidth,
       showOnInit,
       multipleMode,
@@ -150,19 +147,19 @@ export default defineComponent({
       if (props.noDataText === undefined) {
         return t.value.noData;
       }
-      return noDataText;
+      return props.noDataText;
     });
     const localNoMatchText = computed(() => {
       if (props.noMatchText === undefined) {
         return t.value.noMatchedData;
       }
-      return noMatchText;
+      return props.noMatchText;
     });
     const localLoadingText = computed(() => {
       if (props.loadingText === undefined) {
         return t.value.loading;
       }
-      return loadingText;
+      return props.loadingText;
     });
     const localPlaceholder = computed(() => {
       if (props.placeholder === undefined) {

--- a/site/main.ts
+++ b/site/main.ts
@@ -27,7 +27,7 @@
 import { createApp } from 'vue';
 
 import bkuiVue from '../packages/bkui-vue/index';
-// import en from '../packages/locale/src/lang/en';
+import en from '../packages/locale/src/lang/en';
 import zhCn from '../packages/locale/src/lang/zh-cn';
 
 import App from './app';
@@ -35,9 +35,11 @@ import router from './router';
 
 import '../packages/styles/src/index';
 import './reset.less';
+console.error(en);
+console.error(zhCn);
 const app = createApp(App);
 app.use(bkuiVue, {
-  locale: zhCn,
+  locale: en,
 });
 app.use(router);
 

--- a/site/views/select/select-base-demo.vue
+++ b/site/views/select/select-base-demo.vue
@@ -4,6 +4,8 @@
     class="bk-select"
     filterable
     auto-focus
+    no-data-text="sdsd"
+    no-match-text="kkk"
     @toggle="handleToggle"
   >
     <bk-option


### PR DESCRIPTION
<!--
请保证PR标题明确清晰, 易于理解
Keep PR title verbose enough

相关issue可以是 #编号 或者贴 issue链接
`Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


## 变更点(Changes)

- fix: select noDataText, noMatchText, loadingText 三个属性设置之后导致销毁 dom 报错的问题 
- 文档网站默认语言切换为英文 
- bump to 0.0.1-beta.403