### PR TITLE
feat: bump to 0.0.1-beat.474 && 修复 pop-manager onMaskClickFn 中 this.clickFn 为 undefined 导致的报错

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bkui-vue",
   "private": true,
-  "version": "0.0.1-beta.473",
+  "version": "0.0.1-beta.474",
   "workspaces": {
     "packages": [
       "packages/!(**.bak)*",

--- a/packages/shared/src/pop-manager.ts
+++ b/packages/shared/src/pop-manager.ts
@@ -147,9 +147,11 @@ export class BKPopIndexManager {
   }
 
   private onMaskClickFn(e: MouseEvent) {
-    const { fn } = this.clickFn;
-    if (fn) {
-      Reflect.apply(fn, this, [e]);
+    if (this.clickFn) {
+      const { fn } = this.clickFn;
+      if (fn) {
+        Reflect.apply(fn, this, [e]);
+      }
     }
   }
 }


### PR DESCRIPTION
<!--
请保证PR标题明确清晰, 易于理解
Keep PR title verbose enough

相关issue可以是 #编号 或者贴 issue链接
`Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


## 变更点(Changes)

- feat: bump to 0.0.1-beat.474 && 修复 pop-manager onMaskClickFn 中 this.clickFn 为 undefined 导致的报错