### PR TITLE
feat: 修复 taginput max-data 限制为1，标签无法在失焦时自动创建的问题；修复 select 自定义创建模式下禁用键盘事件

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bkui-vue",
-  "version": "0.0.2-beta.121",
+  "version": "0.0.2-beta.123",
   "private": true,
   "workspaces": {
     "packages": [

--- a/packages/tag-input/src/tag-input.tsx
+++ b/packages/tag-input/src/tag-input.tsx
@@ -434,15 +434,16 @@ export default defineComponent({
         // this.dispatch('bk-form-item', 'form-blur')
         state.isEdit = false;
 
-        if (isSingleSelect.value) {
-          const [oldValue] = listState.tagListCache;
-          // 如果是单选，且input不为空，即保留了上次的结果则恢复
-          if (inputValue && inputValue === oldValue && listState.selectedTagListCache.length) {
-            addTag(listState.selectedTagListCache[0], 'select');
-          } else {
-            handleChange('remove');
+        if (props.allowAutoMatch && inputValue) {
+          if (isSingleSelect.value) {
+            const [oldValue] = listState.tagListCache;
+            // 如果是单选，且input不为空，即保留了上次的结果则恢复
+            if (inputValue === oldValue && listState.selectedTagListCache.length) {
+              addTag(listState.selectedTagListCache[0], 'select');
+            } else {
+              handleChange('remove');
+            }
           }
-        } else if (props.allowAutoMatch && inputValue) {
           // 如果匹配，则自动选则
           const matchItem = pageState.curPageList.find(item => {
             if (Array.isArray(props.searchKey)) {
@@ -451,6 +452,7 @@ export default defineComponent({
             }
             return item[props.searchKey] === inputValue;
           });
+
           if (matchItem) {
             handleTagSelected(matchItem, 'select');
           } else if (props.allowCreate) {
@@ -458,6 +460,7 @@ export default defineComponent({
             handleTagSelected(inputValue, 'custom');
           }
         }
+
         popoverProps.isShow = false;
         emit('blur', inputValue, tagList.value);
         formItem?.validate?.('blur');


### PR DESCRIPTION
<!--
请保证PR标题明确清晰, 易于理解
Keep PR title verbose enough

相关issue可以是 #编号 或者贴 issue链接
`Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


## 变更点(Changes)

- 修复 taginput max-data 限制为1，标签无法在失焦时自动创建的问题
- 修复 select 自定义创建模式下禁用键盘事件