### PR TITLE
fix: searchSelect下name设置固定宽度文字会被遮挡问题

### DIFF
--- a/packages/search-select/src/search-select.less
+++ b/packages/search-select/src/search-select.less
@@ -365,7 +365,7 @@
 
       .menu-name {
         display: flex;
-        max-width: 100px;
+        // max-width: 100px;
         margin-right: 5px;
         font-weight: bold;
         color: @search-select-font-color;


### PR DESCRIPTION
fix: searchSelect下name设置固定宽度文字会被遮挡问题(https://github.com/TencentBlueKing/bkui-vue3/issues/2194)