### PR TITLE
feat(cascader): 新增 panel 插槽用于自定义面板内容

### DIFF
--- a/packages/cascader/CLAUDE.md
+++ b/packages/cascader/CLAUDE.md
@@ -1,0 +1,86 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is the Cascader component package for the bkui-vue3 component library. The Cascader is a Vue 3 component that allows users to select options from a hierarchical data structure through a cascading panel interface.
+
+## Common Development Commands
+
+### Building
+```bash
+yarn build
+```
+
+### Testing
+```bash
+yarn test
+```
+
+### Linting
+```bash
+yarn lint
+```
+
+### Root Project Commands (from bkui-vue3 root)
+```bash
+# Development
+yarn dev
+
+# Building the entire library
+yarn build
+
+# Linting all packages
+yarn lint
+
+# Running tests
+yarn test:unit
+```
+
+## Code Architecture
+
+### Component Structure
+- `cascader.tsx` - Main component that handles the UI, popover, input, and tag management
+- `cascader-panel.tsx` - Panel component that displays the hierarchical options
+- `store.ts` - Data store that manages the node hierarchy and selection state
+- `node.ts` - Node class that represents individual items in the hierarchy
+- `interface.tsx` - TypeScript interfaces for type safety
+
+### Key Implementation Details
+
+1. **Data Management**:
+   - Uses a Store class to manage the hierarchical data structure
+   - Nodes are represented by the Node class which handles parent-child relationships
+   - Selection state is managed through the store with support for both single and multiple selection
+
+2. **UI Components**:
+   - Main cascader component handles the input field, tags (for multiple selection), and popover
+   - Cascader panel displays the hierarchical options in columns
+   - Supports both single and multiple selection modes
+
+3. **Key Features**:
+   - Multiple selection with tag display
+   - Search/filter functionality
+   - Remote data loading
+   - Customizable node rendering
+   - Keyboard navigation support
+   - Check-any-level option for selecting parent nodes
+
+4. **Event Handling**:
+   - Node expansion through click or hover triggers
+   - Selection updates propagate through the component hierarchy
+   - Model updates are emitted to parent components
+
+### Data Flow
+1. Props are passed to the Store which creates Node instances
+2. Nodes maintain their state (checked, expanded, etc.)
+3. User interactions update the node states
+4. Changes are propagated back through events to update the modelValue
+5. Watchers ensure UI updates when modelValue changes
+
+### Important Implementation Notes
+- The cascader has special handling for multi-select mode to ensure proper panel behavior
+- Remote data loading is supported through the `remoteMethod` prop
+- The component distinguishes between initial loading and user interactions to handle panel expansion correctly
+- CSS classes use a prefix system for styling consistency

--- a/packages/cascader/README.md
+++ b/packages/cascader/README.md
@@ -1,75 +1,39 @@
-# Cascader
+# Cascader 级联选择器
 
-## 2025-04-11 修复日志
+一个 Vue 3 组件，允许用户通过级联面板界面从分层数据结构中进行选择。
 
-### 问题描述
+## 功能特性
 
-https://github.com/TencentBlueKing/bkui-vue3/issues/2308
+### 面板插槽 (Panel Slot)
 
-### 问题根源
+`Cascader` 组件现在支持面板级别的插槽，允许您自定义每个面板的内容。此功能对于向每个面板添加自定义标题或其他元素非常有用。
 
-级联选择器在多选模式下有一个特殊设计：当用户选择一个节点时，需要显示该节点的子节点面板。问题出在每次用户选择后，会触发以下流程：
+#### 用法
 
-1. 用户点击节点 → 节点被选中 → 更新 `modelValue`
-2. `modelValue` 更新触发 `watch` 回调 → 调用 `updateCheckValue` 函数
-3. `updateCheckValue` 函数会调用 `expandByNodeList` 函数
-4. 原始的 `expandByNodeList` 函数会尝试展开所有选中路径中最长的那个路径的所有节点
+```vue
+<template>
+  <bk-cascader v-model="value" :list="data">
+    <template #panel="{ nodes, level }">
+      <div class="custom-panel-header">
+        面板层级: {{ level }}, 节点数量: {{ nodes.length }}
+      </div>
+    </template>
+  </bk-cascader>
+</template>
+```
 
-关键问题在于第4步：即使用户只是点击了节点B，函数也会重新展开所有已选中的节点（包括之前选中的节点A），这导致面板显示混乱。
+#### 插槽作用域属性
 
-### 修复方案的核心理念
+`panel` 插槽提供以下属性：
 
-彻底改变了 `expandByNodeList` 函数的工作方式，引入了两种不同的工作模式：
+-   `nodes`: 当前面板级别的节点数组。
+-   `level`: 当前面板的从零开始的索引。
+-   `activePath`: `cascader` 中的当前活动路径。
 
-1. **初始加载模式**：组件第一次加载或重置时（`checkValue.value.length === 0`），需要展开所有选中路径
-2. **用户交互模式**：用户点击节点时，只展开当前点击的节点，不影响其他面板
+## 更新日志
 
-### 修复的关键代码解析
+### 2025-04-11
 
-1. **区分场景**：
-   ```typescript
-   const isInitialLoad = checkValue.value.length === 0;
-   if (isInitialLoad || !store.config.multiple) {
-     // 初始加载或单选模式的逻辑
-   }
-   // 用户交互过程中的选择由nodeExpandHandler单独处理，这里不干预
-   ```
+-   **修复：多选模式下面板展开不正确的问题 ([#2308](https://github.com/TencentBlueKing/bkui-vue3/issues/2308))**
 
-2. **避免调用 `nodeExpandHandler`**：
-   原代码中每次都调用 `nodeExpandHandler(node)`，这会触发重复展开。我们改为直接操作数据：
-   ```typescript
-   const expandNode = (node: INode) => {
-     // 直接修改 menus.list 和 activePath，而不调用 nodeExpandHandler
-   };
-   ```
-
-3. **精确控制展开层级**：
-   ```typescript
-   menus.list = menus.list.slice(0, level);
-   activePath.value = activePath.value.slice(0, level - 1);
-   
-   if (node.children?.length) {
-     if (menus.list.length === level) {
-       menus.list.push(node.children);
-       activePath.value.push(node);
-     }
-   }
-   ```
-
-4. **递归处理父节点**：
-   ```typescript
-   const expandParents = (node: INode) => {
-     if (node.parent) {
-       expandParents(node.parent);
-     }
-     expandNode(node);
-   };
-   ```
-
-### 为什么这个修复有效
-
-1. 用户交互时，我们不再干预面板展开，完全依赖用户点击触发的 `nodeExpandHandler`
-2. 初始加载时，我们仍然会按照原来的需求展开所有节点
-3. 不再反复调用 `nodeExpandHandler`，避免了控制台打印的重复日志和不必要的状态更新
-4. 保持了单选模式的原有行为，只修改了多选模式的行为
-
+    重构了面板展开逻辑，以区分初始加载和用户交互。现在，当用户选择一个节点时，只会展开相关的面板，防止其他面板受到影响，从而创造更可预测的用户体验。

--- a/packages/cascader/src/cascader-panel.tsx
+++ b/packages/cascader/src/cascader-panel.tsx
@@ -374,11 +374,12 @@ export default defineComponent({
       <div class={this.resolveClassName('cascader-panel-wrapper')}>
         {this.isFiltering
           ? searchPanelRender()
-          : this.menus.list.map(menu => (
+          : this.menus.list.map((menu, index) => (
               <ul
                 style={{ height: this.panelHeight, width: this.panelWidth }}
                 class={[this.resolveClassName('cascader-panel'), this.resolveClassName('scroll-y')]}
               >
+                {this.$slots.panel?.({ nodes: menu, level: index, activePath: this.activePath })}
                 {menu.length ? (
                   menu.map(node => (
                     <li

--- a/packages/cascader/src/cascader.tsx
+++ b/packages/cascader/src/cascader.tsx
@@ -517,6 +517,7 @@ export default defineComponent({
                     ) : (
                       <span class={this.resolveClassName('cascader-node-name')}>{scope.node.name}</span>
                     ),
+                  panel: scope => (this.$slots.panel ? this.$slots.panel(scope) : null),
                 }}
                 is-filtering={this.isFiltering}
                 search-key={this.searchKey}

--- a/site/views/cascader/index.tsx
+++ b/site/views/cascader/index.tsx
@@ -37,6 +37,7 @@ import CustomFillback from './custom-fillback.vue';
 import CustomTriggerDemo from './custom-trigger-demo.vue';
 import ExtensionDemo from './extension-demo.vue';
 import IdKey from './id-key.vue';
+import PanelSlotDemo from './panel-slot-demo.vue';
 import RemoteDemo from './remote-demo.vue';
 import SeparatorDemo from './separator-demo.vue';
 import ShowCompleteName from './show-complete-name.vue';
@@ -366,6 +367,15 @@ export default defineComponent({
           title='自定义填充回调'
         >
           <CustomFillback></CustomFillback>
+        </DemoBox>
+
+        <DemoBox
+          componentName='cascader'
+          demoName='panel-slot-demo'
+          desc='通过 panel 插槽，可自定义每一级面板的内容'
+          title='自定义面板'
+        >
+          <PanelSlotDemo />
         </DemoBox>
 
         {/* 扩展插槽 */}

--- a/site/views/cascader/panel-slot-demo.vue
+++ b/site/views/cascader/panel-slot-demo.vue
@@ -1,0 +1,81 @@
+<template>
+  <div>
+    <bk-cascader
+      v-model="area"
+      :list="list"
+      :check-any-level="true"
+      multiple
+    >
+      <template #panel="{ nodes, level }">
+        <div class="custom-panel-header" @click="handleClick(nodes, level)">
+          Panel Level: {{ level }}, Nodes: {{ nodes.length }}
+        </div>
+      </template>
+    </bk-cascader>
+  </div>
+</template>
+
+<script>
+  import { defineComponent, ref } from 'vue';
+
+  export default defineComponent({
+    setup() {
+      const list = ref([
+        {
+          id: 'hunan',
+          name: '湖南',
+          children: [
+            {
+              id: 'changsha',
+              name: '长沙',
+              children: [
+                { id: 'yuelu', name: '岳麓区' },
+                { id: 'kaifu', name: '开福区' },
+                { id: 'furong', name: '芙蓉区' },
+              ],
+            },
+            {
+              id: 'yueyang',
+              name: '岳阳',
+            },
+          ],
+        },
+        {
+          id: 'guangdong',
+          name: '广东',
+          children: [
+            {
+              id: 'guangzhou',
+              name: '广州',
+            },
+            {
+              id: 'shenzhen',
+              name: '深圳',
+            },
+          ],
+        },
+      ]);
+      const area = ref([]);
+
+      const handleClick = (nodes, level) =>{
+        console.log('nodes', nodes, 'level', level)
+      }
+
+      return {
+        list,
+        area,
+        handleClick
+      };
+    },
+  });
+</script>
+
+<style lang="less" scoped>
+.custom-panel-header {
+  padding: 5px 12px;
+  font-size: 12px;
+  color: #63656e;
+  background: #f0f1f5;
+  border-bottom: 1px solid #dcdee5;
+}
+</style>


### PR DESCRIPTION
  - 为 Cascader 组件引入了一个新的 #panel 插槽，允许对每个 面板的内容进行自定义渲染，从而提供了更大的灵活性。
  - 插槽作用域包含 nodes、level 和 activePath，方便进行定制。
  - 添加了新的演示示例来说明 panel 插槽的用法。

<!--
请保证PR标题明确清晰, 易于理解
Keep PR title verbose enough

相关issue可以是 #编号 或者贴 issue链接
`Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


## 变更点(Changes)

- xxxx

## 相关issues (Which issues this PR fixes)

- Fixes #

## 备注(Special notes)
