### PR TITLE
fix(code-diff): 将 diff2html 样式从 JS import 迁移至 less 文件引入

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "scripts/cli",
     "site"
   ],
+  "private": true,
   "files": [
     "lib",
     "dist"

--- a/packages/code-diff/src/code-diff.less
+++ b/packages/code-diff/src/code-diff.less
@@ -1,5 +1,5 @@
 @import '@bkui-vue/styles/themes/themes.less';
-// @import 'diff2html/bundles/css/diff2html.min.css';
+@import 'diff2html/bundles/css/diff2html.min.css';
 
 // TODO: theme var
 

--- a/packages/code-diff/src/code-diff.tsx
+++ b/packages/code-diff/src/code-diff.tsx
@@ -32,7 +32,7 @@ import { classes, ElementType, PropTypes, stringEnum } from '@bkui-vue/shared';
 import { createPatch } from 'diff';
 import * as Diff2Html from 'diff2html';
 
-import 'diff2html/bundles/css/diff2html.min.css';
+// import 'diff2html/bundles/css/diff2html.min.css';
 
 const diffFormats = ['side-by-side', 'line-by-line'] as const;
 const CodeDiffFormat = stringEnum([...diffFormats]);

--- a/scripts/cli/compiler/compile-style.ts
+++ b/scripts/cli/compiler/compile-style.ts
@@ -24,25 +24,48 @@
  * IN THE SOFTWARE.
  */
 
+import { existsSync } from 'fs';
 import { readFile } from 'fs/promises';
 import { render } from 'less';
+import { resolve } from 'path';
 import postcss from 'postcss';
 import postcssLess from 'postcss-less';
 
 import LessResolvePathPlugin from '../utils/less-plugin';
 import { transformCssImport } from '../utils/postcss-plugin';
+import { BKUI_DIR } from './helpers';
+
+const nodeModulesPath = resolve(BKUI_DIR, 'node_modules');
+
+async function inlineNodeModulesCss(source: string): Promise<string> {
+  const importRegex = /@import\s+(?:\(inline\)\s+)?['"]([^@.][^'"]*\.css)['"]\s*;/g;
+  let result = source;
+  let match;
+  while ((match = importRegex.exec(source)) !== null) {
+    const fullPath = resolve(nodeModulesPath, match[1]);
+    if (existsSync(fullPath)) {
+      const content = await readFile(fullPath, 'utf-8');
+      result = result.replace(match[0], content);
+    }
+  }
+  return result;
+}
+
 export const compileStyle = async (url: string) => {
   const resource = await readFile(url, 'utf-8');
   const varResource = resource.replace(/\/themes\/themes\.less/gim, '/themes/themes.variable.less');
   const { css } = await render(resource, {
     filename: url,
+    paths: [nodeModulesPath],
     plugins: [new LessResolvePathPlugin()],
   });
   const { css: varCss } = await render(varResource, {
     filename: url,
+    paths: [nodeModulesPath],
     plugins: [new LessResolvePathPlugin()],
   });
-  const ret = await postcss([transformCssImport(url)]).process(resource, { syntax: postcssLess });
+  const inlinedResource = await inlineNodeModulesCss(resource);
+  const ret = await postcss([transformCssImport(url)]).process(inlinedResource, { syntax: postcssLess });
   return { css, varCss, resource: ret.css };
 };
 


### PR DESCRIPTION
## Summary

- 在 `code-diff.less` 中恢复 `diff2html` CSS 的 `@import`，移除 `code-diff.tsx` 中的直接 JS import
- 构建脚本新增 `inlineNodeModulesCss` 函数，支持将 `node_modules` 中的 CSS 内联到 less 产物
- `less render` 添加 `paths` 配置，支持从 `node_modules` 解析路径
- `package.json` 添加 `private: true`，防止根包被误发布到 npm

## Test plan

- [ ] 构建 `code-diff` 包，确认 `diff2html` 样式正常包含在产物中
- [ ] 本地启动 dev 环境，验证 code-diff 组件样式渲染正常

Made with [Cursor](https://cursor.com)