### PR TITLE
fix(search-select): 修复选中项布局对齐及溢出展示优化 (#2644)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ pre-*-bkcodeai
 /preset
 .aider*
 .env
+.cursor/skills/*

--- a/packages/search-select/src/search-select.less
+++ b/packages/search-select/src/search-select.less
@@ -18,9 +18,7 @@
 
   .div-input {
     flex: 1 1 auto;
-    height: 100%;
-    padding: 5px 0;
-    line-height: 20px;
+    line-height: 22px;
     word-break: break-all;
 
     &:focus {
@@ -35,7 +33,7 @@
     flex-direction: row;
     flex-wrap: wrap;
     align-items: center;
-    min-height: 30px;
+    min-height: @component-size-base;
     overflow: hidden;
     font-size: 12px;
     color: @search-select-font-color;
@@ -70,19 +68,19 @@
       max-width: calc(100% - 42px);
       min-height: 26px;
       padding: 0 2px;
-      margin-top: 4px;
       overflow: visible;
       text-align: left;
       transition: max-height 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 
       &-selected {
         position: relative;
-        display: inline-block;
+        display: inline-flex;
         flex: 0 0 auto;
+        align-items: center;
         align-self: center;
         max-width: 99%;
         padding-left: 8px;
-        margin: 0 0 4px 6px;
+        margin: 2px 0 2px 6px;
         line-height: 22px;
         color: @search-select-font-color;
         background: #f0f1f5;
@@ -106,8 +104,11 @@
 
         .selected-name {
           display: inline-block;
+          max-width: calc(100% - 20px);
           margin-right: 20px;
-          word-break: break-all;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
         }
 
         .selected-clear {
@@ -130,12 +131,12 @@
 
       &-input {
         position: relative;
-        display: block;
+        display: flex;
         flex: 1;
+        align-items: center;
+        align-self: center;
         min-width: 40px;
-        height: 100%;
         padding: 0 10px;
-        margin-top: -4px;
         color: @search-select-font-color;
         border: none;
 
@@ -155,14 +156,24 @@
         }
       }
 
+      .overflow-popover-ref {
+        display: inline-flex;
+        align-self: center;
+      }
+
+      &.has-overflow {
+        .search-container-selected:not(.overflow-selected) {
+          max-width: calc(100% - 40px);
+        }
+      }
+
       .selected-input {
         position: relative;
         display: flex;
         align-items: center;
+        align-self: center;
         min-width: 40px;
-        height: 100%;
         padding: 0 10px;
-        margin-top: -4px;
         color: @search-select-font-color;
         border: none;
       }
@@ -406,4 +417,17 @@
 
 .@{search-select-name}-popover {
   margin: -12px;
+}
+
+.overflow-tips-content {
+  max-height: 200px;
+  padding: 4px 0;
+  overflow: auto;
+
+  .overflow-tips-item {
+    padding: 2px 0;
+    font-size: 12px;
+    line-height: 20px;
+    word-break: break-all;
+  }
 }

--- a/packages/search-select/src/search-select.tsx
+++ b/packages/search-select/src/search-select.tsx
@@ -263,25 +263,22 @@ export default defineComponent({
       const maxWidth = wrapRef.value.querySelector('.search-container').clientWidth - SELECTED_MARGIN_RIGHT - 2;
       const tagList = inputEl.querySelectorAll('.search-container-selected:not(.overflow-selected)');
       let width = 0;
-      let index = 0;
-      let i = 0;
-      while (index === 0 && width <= maxWidth - INPUT_PADDING_WIDTH && i <= tagList.length - 1) {
+      let overflowIdx = -1;
+
+      for (let i = 0; i < tagList.length; i++) {
         const el = tagList[i];
-        if (el.clientHeight > INPUT_MIN_HEIGHT) {
-          overflowIndex.value = i;
-          return;
-        }
         width += el ? el.clientWidth + SELECTED_MARGIN_RIGHT : 0;
-        if (width >= maxWidth - INPUT_PADDING_WIDTH) {
-          index = i;
+        if (el.clientHeight > INPUT_MIN_HEIGHT || width >= maxWidth - INPUT_PADDING_WIDTH) {
+          overflowIdx = i;
+          break;
         }
-        i += 1;
       }
-      if (index === tagList.length - 1 && width <= maxWidth) {
+
+      if (overflowIdx < 0 || overflowIdx >= tagList.length) {
         overflowIndex.value = -1;
         return;
       }
-      overflowIndex.value = width >= maxWidth - INPUT_PADDING_WIDTH ? index : index - 1;
+      overflowIndex.value = overflowIdx;
     }
     function handleWrapClick() {
       if (!editKey.value) {
@@ -384,7 +381,7 @@ export default defineComponent({
           <div class='search-prefix'>{this.$slots.prepend?.()}</div>
           <div
             style={{ 'max-height': `${maxHeight}px` }}
-            class='search-container'
+            class={`search-container ${this.overflowIndex >= 0 ? 'has-overflow' : ''}`}
           >
             <SearchSelected
               v-slots={{ ...menuSlots }}

--- a/packages/search-select/src/selected.tsx
+++ b/packages/search-select/src/selected.tsx
@@ -25,8 +25,8 @@
  */
 import { defineComponent, PropType, ref } from 'vue';
 
+import { bkTooltips } from '@bkui-vue/directives';
 import { Error } from '@bkui-vue/icon';
-import Popover from '@bkui-vue/popover';
 
 import SearchSelectInput from './input';
 import {
@@ -42,6 +42,9 @@ import {
 } from './utils';
 export default defineComponent({
   name: 'SearchSelected',
+  directives: {
+    bkTooltips,
+  },
   props: {
     data: {
       type: Array as PropType<ISearchItem[]>,
@@ -165,32 +168,19 @@ export default defineComponent({
       <>
         {this.selectedList.map((item, index) => [
           this.overflowIndex >= 0 && index === this.overflowIndex && (
-            <Popover
-              placement='bottom-start'
-              theme='light'
-              popoverDelay={[200, 0]}
-              referenceCls='overflow-popover-ref'
-            >
-              {{
-                default: () => (
-                  <div class='search-container-selected overflow-selected'>
-                    +{this.selectedList.length - this.overflowIndex}
-                  </div>
-                ),
-                content: () => (
-                  <div class='overflow-tips-content'>
-                    {this.selectedList.slice(this.overflowIndex).map((overflowItem, idx) => (
-                      <div
-                        key={idx}
-                        class='overflow-tips-item'
-                      >
-                        {overflowItem.inputInnerText}
-                      </div>
-                    ))}
-                  </div>
-                ),
+            <div
+              class='search-container-selected overflow-selected'
+              v-bk-tooltips={{
+                content: this.selectedList
+                  .slice(this.overflowIndex)
+                  .map(item => item.inputInnerText)
+                  .join('\n'),
+                placement: 'bottom-start',
+                theme: 'light',
               }}
-            </Popover>
+            >
+              +{this.selectedList.length - this.overflowIndex}
+            </div>
           ),
           contentComponent(item, index),
         ])}

--- a/packages/search-select/src/selected.tsx
+++ b/packages/search-select/src/selected.tsx
@@ -26,6 +26,7 @@
 import { defineComponent, PropType, ref } from 'vue';
 
 import { Error } from '@bkui-vue/icon';
+import Popover from '@bkui-vue/popover';
 
 import SearchSelectInput from './input';
 import {
@@ -149,6 +150,7 @@ export default defineComponent({
         >
           <span
             class='selected-name'
+            title={item.inputInnerText}
             onClick={e => this.handleEditSelected(e, item, index)}
           >
             {item.inputInnerText}
@@ -163,9 +165,32 @@ export default defineComponent({
       <>
         {this.selectedList.map((item, index) => [
           this.overflowIndex >= 0 && index === this.overflowIndex && (
-            <div class='search-container-selected overflow-selected'>
-              +{this.selectedList.length - this.overflowIndex}
-            </div>
+            <Popover
+              placement='bottom-start'
+              theme='light'
+              popoverDelay={[200, 0]}
+              referenceCls='overflow-popover-ref'
+            >
+              {{
+                default: () => (
+                  <div class='search-container-selected overflow-selected'>
+                    +{this.selectedList.length - this.overflowIndex}
+                  </div>
+                ),
+                content: () => (
+                  <div class='overflow-tips-content'>
+                    {this.selectedList.slice(this.overflowIndex).map((overflowItem, idx) => (
+                      <div
+                        key={idx}
+                        class='overflow-tips-item'
+                      >
+                        {overflowItem.inputInnerText}
+                      </div>
+                    ))}
+                  </div>
+                ),
+              }}
+            </Popover>
           ),
           contentComponent(item, index),
         ])}


### PR DESCRIPTION
## Summary

- 修复选中标签布局，改用 inline-flex 对齐方式解决垂直居中问题
- 优化溢出计算逻辑，简化 while 循环为 for 循环并修正边界判断
- 溢出指示器增加 Popover 悬浮提示，展示被折叠的选中项详情
- 选中项名称添加文本溢出省略号及 title 属性，防止长文本撑开布局
- .gitignore 新增 .cursor/skills/* 忽略规则

## Test plan

- [ ] 构建验证
- [ ] 本地功能验证


Made with [Cursor](https://cursor.com)