### PR TITLE
fix(select): 修复下拉过滤条件清空后列表没有重置的问题

### DIFF
--- a/packages/select/__test__/select.test.ts
+++ b/packages/select/__test__/select.test.ts
@@ -446,6 +446,58 @@ describe('Select.tsx', () => {
     }, 400);
   });
 
+  // slot + 下拉搜索：关闭后再打开应恢复完整列表（搜索框已清空）
+  test('reset option visible after dropdown search close', async () => {
+    const wrapper = mount({
+      components: {
+        BkSelect,
+        BkOption,
+      },
+      template: `
+        <BkSelect v-model="seletValue" filterable>
+          <BkOption v-for="item in options" :key="item.value" :id="item.value" :name="item.label"></BkOption>
+        </BkSelect>
+      `,
+      data() {
+        return {
+          seletValue: '',
+          options: [
+            { value: 1, label: 'apple' },
+            { value: 2, label: 'banana' },
+            { value: 3, label: 'orange' },
+            { value: 4, label: 'grape' },
+          ],
+        };
+      },
+    });
+
+    await wrapper.find('.bk-select-trigger').trigger('click');
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    const searchInput = document.querySelector('.bk-select-search-input') as HTMLInputElement | null;
+    expect(searchInput).toBeTruthy();
+    searchInput!.value = 'apple';
+    searchInput!.dispatchEvent(new Event('input'));
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    const select = wrapper.findComponent(BkSelect);
+    expect(select.vm.searchValue).toBe('apple');
+    expect(wrapper.findAllComponents({ name: 'Option' }).filter(com => com.vm.visible).length).toBe(1);
+
+    await wrapper.find('.bk-select-trigger').trigger('click');
+    await nextTick();
+    expect(select.vm.isPopoverShow).toBe(false);
+    expect(select.vm.searchValue).toBe('');
+
+    await wrapper.find('.bk-select-trigger').trigger('click');
+    await new Promise(resolve => setTimeout(resolve, 50));
+    expect(select.vm.isPopoverShow).toBe(true);
+    expect(select.vm.searchValue).toBe('');
+    expect(wrapper.findAllComponents({ name: 'Option' }).filter(com => com.vm.visible).length).toBe(4);
+
+    wrapper.unmount();
+  });
+
   // 虚拟滚动功能
   test('virtual select', async () => {
     const wrapper = await mount(BkSelect, {

--- a/packages/select/src/select.tsx
+++ b/packages/select/src/select.tsx
@@ -575,6 +575,11 @@ export default defineComponent({
     // );
     // 自定义创建失焦后仍保留输入框内的内容
     const isInput = computed(() => (filterable.value && inputSearch.value && isPopoverShow.value) || allowCreate.value);
+    const resetOptionVisible = () => {
+      options.value.forEach(option => {
+        option.visible = true;
+      });
+    };
     watch(isPopoverShow, isShow => {
       emit('toggle', isPopoverShow.value);
       if (!isShow) {
@@ -585,6 +590,10 @@ export default defineComponent({
       } else {
         // 打开时刷新一次 slot options 元信息（用于虚拟模式回显/空态判断）
         refreshSlotOptionMetaMap();
+        // 搜索已空时复位 slot option 可见性，避免上次下拉过滤态残留
+        if (!searchValue.value) {
+          resetOptionVisible();
+        }
         document.addEventListener('keydown', handleDocumentKeydown);
         setTimeout(() => {
           focusInput();
@@ -666,21 +675,23 @@ export default defineComponent({
     // 处理options模式时默认搜索方法
     const handleDefaultOptionSearch = (searchValue: string) => {
       if (!filterable.value) return;
+
+      // 关键字为空必须复位可见性。slot 模式下关闭下拉会先把 isPopoverShow 置 false
+      // 再清空 searchValue；若此处直接 return，option.visible 会停在上次过滤态。
+      if (!searchValue) {
+        resetOptionVisible();
+        return;
+      }
+
       // Popover 关闭时：下拉搜索无需处理；但 inputSearch/allowCreate 仍需要更新可见性
       if (!isPopoverShow.value && !(inputSearch.value || allowCreate.value)) return;
 
-      if (!searchValue) {
-        options.value.forEach(option => {
-          option.visible = true;
+      options.value.forEach(option => {
+        option.visible = defaultSearchMethod(searchValue, String(option.optionName), {
+          ...option.$props,
+          ...option.$attrs,
         });
-      } else {
-        options.value.forEach(option => {
-          option.visible = defaultSearchMethod(searchValue, String(option.optionName), {
-            ...option.$props,
-            ...option.$attrs,
-          });
-        });
-      }
+      });
     };
     const { searchValue, customOptionName, curSearchValue, searchLoading } = useRemoteSearch(
       isRemoteSearch.value ? remoteMethod.value : handleDefaultOptionSearch,


### PR DESCRIPTION
Closing a filterable slot Select cleared the keyword but skipped the search callback, so option.visible stayed filtered until the next keyword change.

<!--
请保证PR标题明确清晰, 易于理解
Keep PR title verbose enough

相关issue可以是 #编号 或者贴 issue链接
`Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


## 变更点(Changes)

- xxxx

## 相关issues (Which issues this PR fixes)

- Fixes #

## 备注(Special notes)
